### PR TITLE
Fix malformed go.sum for Go 1.22

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -19,4 +19,3 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-/.github/


### PR DESCRIPTION
Go 1.22 seems to be more strict with go.sum syntax, reporting an error:

````
go1.22rc1 build
malformed go.sum:
[...]/URLFinder/go.sum:22: wrong number of fields 1
````

fixes #95