### PR TITLE
Error FIxed

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -19,4 +19,3 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-/.github/


### PR DESCRIPTION
go build -o URLFinder main.go && cp URLFinder $HOME/go/bin/ malformed go.sum:
/root/Tools/Harvex/URLFinder/go.sum:22: wrong number of fields 1