### PR TITLE
修复抓取稳定性与输出安全问题

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-var Update = "2023.9.9"
+var Update = "2026.6.16"
 var XUpdate string
 
 var (

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pingc0y/URLFinder/config"
 	"github.com/pingc0y/URLFinder/result"
 	"github.com/pingc0y/URLFinder/util"
-	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -31,7 +30,7 @@ func Spider(u string, num int) {
 	//标记完成
 
 	u, _ = url.QueryUnescape(u)
-	if num > 1 && cmd.D != "" && !regexp.MustCompile(cmd.D).MatchString(u) {
+	if num > 1 && cmd.D != "" && !util.RegexpMatch(cmd.D, u) {
 		return
 	}
 	if GetEndUrl(u) {
@@ -97,14 +96,14 @@ func Spider(u string, num int) {
 			return
 		}
 		defer reader.Close()
-		con, err := io.ReadAll(reader)
+		con, err := util.ReadAllLimited(reader)
 		if err != nil {
 			return
 		}
 		result = string(con)
 	} else {
 		//提取url用于拼接其他url或js
-		dataBytes, err := io.ReadAll(response.Body)
+		dataBytes, err := util.ReadAllLimited(response.Body)
 		if err != nil {
 			return
 		}

--- a/crawler/filter.go
+++ b/crawler/filter.go
@@ -56,6 +56,10 @@ func urlFilter(str [][]string) [][]string {
 			str[i][0] = ""
 			continue
 		}
+		if isNonFetchableReference(str[i][0]) {
+			str[i][0] = ""
+			continue
+		}
 
 		//对抓到的域名做处理
 		re := regexp.MustCompile("([a-z0-9\\-]+\\.)+([a-z0-9\\-]+\\.[a-z0-9\\-]+)(:[0-9]+)?").FindAllString(str[i][0], 1)
@@ -75,4 +79,20 @@ func urlFilter(str [][]string) [][]string {
 
 	}
 	return str
+}
+
+func isNonFetchableReference(raw string) bool {
+	ref := strings.TrimSpace(raw)
+	if ref == "" || strings.HasPrefix(ref, "#") {
+		return true
+	}
+	if strings.HasPrefix(ref, "/") {
+		return false
+	}
+	parsed, err := url.Parse(ref)
+	if err != nil || parsed.Scheme == "" {
+		return false
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	return scheme != "http" && scheme != "https"
 }

--- a/crawler/filter_test.go
+++ b/crawler/filter_test.go
@@ -1,0 +1,54 @@
+package crawler
+
+import (
+	"testing"
+
+	"github.com/pingc0y/URLFinder/cmd"
+	"github.com/pingc0y/URLFinder/config"
+	"github.com/pingc0y/URLFinder/result"
+)
+
+func TestUrlFilterDropsNonFetchableReferences(t *testing.T) {
+	matches := [][]string{
+		{"", "data:text/plain"},
+		{"", "mailto:security@example.com"},
+		{"", "javascript:alert(1)"},
+		{"", "#section"},
+		{"", "tel:123456"},
+		{"", "https://target.test/api"},
+		{"", "/api/users"},
+	}
+
+	got := urlFilter(matches)
+
+	for i, want := range []string{"", "", "", "", "", "https://target.test/api", "/api/users"} {
+		if got[i][0] != want {
+			t.Fatalf("urlFilter()[%d] = %q, want %q", i, got[i][0], want)
+		}
+	}
+}
+
+func TestUrlFindDoesNotJoinNonFetchableReferencesToHost(t *testing.T) {
+	oldB, oldD, oldM := cmd.B, cmd.D, cmd.M
+	oldUrlSteps := config.UrlSteps
+	t.Cleanup(func() {
+		cmd.B, cmd.D, cmd.M = oldB, oldD, oldM
+		config.UrlSteps = oldUrlSteps
+	})
+
+	cmd.B = ""
+	cmd.D = ""
+	cmd.M = 1
+	config.UrlSteps = 1
+	Initialization()
+
+	html := `<a href="data:text/plain">bad</a><a href="#section">anchor</a><a href="/api/users">good</a>`
+	urlFind(html, "example.com", "https", "/", "https://example.com", 1)
+
+	if len(result.ResultUrl) != 1 {
+		t.Fatalf("len(result.ResultUrl) = %d, want 1: %#v", len(result.ResultUrl), result.ResultUrl)
+	}
+	if result.ResultUrl[0].Url != "https://example.com/api/users" {
+		t.Fatalf("result url = %q, want %q", result.ResultUrl[0].Url, "https://example.com/api/users")
+	}
+}

--- a/crawler/run.go
+++ b/crawler/run.go
@@ -44,8 +44,8 @@ func load() {
 
 	if cmd.T != 50 {
 		config.Ch = make(chan int, cmd.T)
-		config.Jsch = make(chan int, cmd.T/10*3)
-		config.Urlch = make(chan int, cmd.T/10*7)
+		config.Jsch = make(chan int, validationChannelCap(cmd.T, 3))
+		config.Urlch = make(chan int, validationChannelCap(cmd.T, 7))
 	}
 
 	tr := &http.Transport{
@@ -92,6 +92,14 @@ func load() {
 		},
 	}
 
+}
+
+func validationChannelCap(thread, ratio int) int {
+	capacity := thread / 10 * ratio
+	if capacity < 1 {
+		return 1
+	}
+	return capacity
 }
 
 func Run() {

--- a/crawler/run_test.go
+++ b/crawler/run_test.go
@@ -1,0 +1,42 @@
+package crawler
+
+import (
+	"testing"
+
+	"github.com/pingc0y/URLFinder/cmd"
+	"github.com/pingc0y/URLFinder/config"
+)
+
+func TestLoadKeepsValidationChannelsUsableForSmallThreadCounts(t *testing.T) {
+	oldU, oldF, oldFF := cmd.U, cmd.F, cmd.FF
+	oldI, oldH := cmd.I, cmd.H
+	oldT, oldTI := cmd.T, cmd.TI
+	oldX := cmd.X
+	oldCh, oldJsch, oldUrlch := config.Ch, config.Jsch, config.Urlch
+
+	t.Cleanup(func() {
+		cmd.U, cmd.F, cmd.FF = oldU, oldF, oldFF
+		cmd.I, cmd.H = oldI, oldH
+		cmd.T, cmd.TI = oldT, oldTI
+		cmd.X = oldX
+		config.Ch, config.Jsch, config.Urlch = oldCh, oldJsch, oldUrlch
+	})
+
+	cmd.U = "https://example.com"
+	cmd.F = ""
+	cmd.FF = ""
+	cmd.I = false
+	cmd.H = false
+	cmd.T = 1
+	cmd.TI = 1
+	cmd.X = ""
+
+	load()
+
+	if cap(config.Jsch) < 1 {
+		t.Fatalf("cap(config.Jsch) = %d, want at least 1", cap(config.Jsch))
+	}
+	if cap(config.Urlch) < 1 {
+		t.Fatalf("cap(config.Urlch) = %d, want at least 1", cap(config.Urlch))
+	}
+}

--- a/crawler/state.go
+++ b/crawler/state.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pingc0y/URLFinder/mode"
 	"github.com/pingc0y/URLFinder/result"
 	"github.com/pingc0y/URLFinder/util"
-	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -93,7 +92,7 @@ func JsState(u string, i int, sou string) {
 	code := response.StatusCode
 	if strings.Contains(cmd.S, strconv.Itoa(code)) || cmd.S == "all" && (sou != "Fuzz" && code == 200) {
 		var length int
-		dataBytes, err := io.ReadAll(response.Body)
+		dataBytes, err := util.ReadAllLimited(response.Body)
 		if err != nil {
 			length = 0
 		} else {
@@ -188,7 +187,7 @@ func UrlState(u string, i int) {
 	code := response.StatusCode
 	if strings.Contains(cmd.S, strconv.Itoa(code)) || cmd.S == "all" {
 		var length int
-		dataBytes, err := io.ReadAll(response.Body)
+		dataBytes, err := util.ReadAllLimited(response.Body)
 		if err != nil {
 			length = 0
 		} else {

--- a/crawler/urlFuzz.go
+++ b/crawler/urlFuzz.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pingc0y/URLFinder/mode"
 	"github.com/pingc0y/URLFinder/result"
 	"github.com/pingc0y/URLFinder/util"
-	"io"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -74,7 +73,7 @@ func fuzzGet(u string) {
 	code := response.StatusCode
 	if strings.Contains(cmd.S, strconv.Itoa(code)) || cmd.S == "all" {
 		var length int
-		dataBytes, err := io.ReadAll(response.Body)
+		dataBytes, err := util.ReadAllLimited(response.Body)
 		if err != nil {
 			length = 0
 		} else {

--- a/go.sum
+++ b/go.sum
@@ -19,4 +19,3 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-/.github/

--- a/result/result.go
+++ b/result/result.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pingc0y/URLFinder/cmd"
 	"github.com/pingc0y/URLFinder/mode"
 	"github.com/pingc0y/URLFinder/util"
+	stdhtml "html"
 	"net/url"
 	"os"
 	"regexp"
@@ -34,10 +35,20 @@ var (
 	Redirect map[string]bool
 )
 
+func escapeHTML(s string) string {
+	return stdhtml.EscapeString(s)
+}
+
 func outHtmlString(link mode.Link) string {
+	link.Url = escapeHTML(link.Url)
+	link.Status = escapeHTML(link.Status)
+	link.Size = escapeHTML(link.Size)
+	link.Title = escapeHTML(link.Title)
+	link.Redirect = escapeHTML(link.Redirect)
+	link.Source = escapeHTML(link.Source)
 	ht := `<tr class="ant-table-row ant-table-row-level-0" data-row-key="0">
-				<td class="ant-table-column-has-actions ant-table-column-has-sorters">
-					<a href="` + link.Url + `" target="_blank" >
+					<td class="ant-table-column-has-actions ant-table-column-has-sorters">
+						<a href="` + link.Url + `" target="_blank" >
 						` + link.Url + ` </a>
 				</td>
 				<td class="ant-table-column-has-actions ant-table-column-has-sorters">
@@ -62,9 +73,12 @@ func outHtmlString(link mode.Link) string {
 }
 
 func outHtmlInfoString(ty, val, sou string) string {
+	ty = escapeHTML(ty)
+	val = escapeHTML(val)
+	sou = escapeHTML(sou)
 	ht := `<tr class="ant-table-row ant-table-row-level-0" data-row-key="0">
-				<td class="ant-table-column-has-actions ant-table-column-has-sorters">
-					` + ty + `
+					<td class="ant-table-column-has-actions ant-table-column-has-sorters">
+						` + ty + `
 				</td>
 				<td class="ant-table-column-has-actions ant-table-column-has-sorters">
 					` + val + `
@@ -78,9 +92,10 @@ func outHtmlInfoString(ty, val, sou string) string {
 }
 
 func outHtmlDomainString(domain string) string {
+	domain = escapeHTML(domain)
 	ht := `<tr class="ant-table-row ant-table-row-level-0" data-row-key="0">
-				<td class="ant-table-column-has-actions ant-table-column-has-sorters">
-					` + domain + `
+					<td class="ant-table-column-has-actions ant-table-column-has-sorters">
+						` + domain + `
 				</td>
 			</tr>`
 	return ht

--- a/result/result_test.go
+++ b/result/result_test.go
@@ -1,0 +1,49 @@
+package result
+
+import (
+	stdhtml "html"
+	"strings"
+	"testing"
+
+	"github.com/pingc0y/URLFinder/mode"
+)
+
+func TestOutHtmlStringEscapesLinkFields(t *testing.T) {
+	maliciousURL := `https://example.com/"><script>alert(1)</script>`
+	maliciousTitle := `<img src=x onerror=alert(1)>`
+	link := mode.Link{
+		Url:      maliciousURL,
+		Status:   "200",
+		Size:     "123",
+		Title:    maliciousTitle,
+		Redirect: maliciousURL,
+		Source:   maliciousURL,
+	}
+
+	got := outHtmlString(link)
+
+	for _, raw := range []string{maliciousURL, maliciousTitle} {
+		if strings.Contains(got, raw) {
+			t.Fatalf("outHtmlString() contained unescaped value %q in %q", raw, got)
+		}
+		if !strings.Contains(got, stdhtml.EscapeString(raw)) {
+			t.Fatalf("outHtmlString() did not contain escaped value %q in %q", raw, got)
+		}
+	}
+}
+
+func TestOutHtmlInfoStringEscapesInfoFields(t *testing.T) {
+	rawValue := `<script>alert(1)</script>`
+	rawSource := `https://example.com/"><script>alert(1)</script>`
+
+	got := outHtmlInfoString("Other", rawValue, rawSource)
+
+	for _, raw := range []string{rawValue, rawSource} {
+		if strings.Contains(got, raw) {
+			t.Fatalf("outHtmlInfoString() contained unescaped value %q in %q", raw, got)
+		}
+		if !strings.Contains(got, stdhtml.EscapeString(raw)) {
+			t.Fatalf("outHtmlInfoString() did not contain escaped value %q in %q", raw, got)
+		}
+	}
+}

--- a/util/utils.go
+++ b/util/utils.go
@@ -3,6 +3,7 @@ package util
 import (
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/pingc0y/URLFinder/cmd"
 	"github.com/pingc0y/URLFinder/config"
@@ -17,6 +18,10 @@ import (
 	"strings"
 	"time"
 )
+
+const MaxResponseBodySize int64 = 10 * 1024 * 1024
+
+var ErrResponseTooLarge = errors.New("response body too large")
 
 // MergeArray 合并数组
 func MergeArray(dest []mode.Link, src []mode.Link) (result []mode.Link) {
@@ -111,19 +116,36 @@ func GetProtocol(domain string) string {
 		return domain
 	}
 
-	response, err := http.Get("https://" + domain)
-	if err == nil {
+	if requestOK("https://" + domain) {
 		return "https://" + domain
 	}
-	response, err = http.Get("http://" + domain)
-	if err == nil {
-		return "http://" + domain
-	}
-	defer response.Body.Close()
-	if response.TLS == nil {
+	if requestOK("http://" + domain) {
 		return "http://" + domain
 	}
 	return ""
+}
+
+func requestOK(rawURL string) bool {
+	response, err := http.Get(rawURL)
+	if response != nil && response.Body != nil {
+		response.Body.Close()
+	}
+	return err == nil
+}
+
+func ReadAllLimited(r io.Reader) ([]byte, error) {
+	return readAllLimited(r, MaxResponseBodySize)
+}
+
+func readAllLimited(r io.Reader, max int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > max {
+		return nil, ErrResponseTooLarge
+	}
+	return data, nil
 }
 
 // 提取顶级域名
@@ -205,11 +227,19 @@ func domainNameFilter(url string) string {
 	re := regexp.MustCompile("://([a-z0-9\\-]+\\.)*([a-z0-9\\-]+\\.[a-z0-9\\-]+)(:[0-9]+)?")
 	hosts := re.FindAllString(url, 1)
 	if len(hosts) != 0 {
-		if !regexp.MustCompile(cmd.D).MatchString(hosts[0]) {
+		if !RegexpMatch(cmd.D, hosts[0]) {
 			url = ""
 		}
 	}
 	return url
+}
+
+func RegexpMatch(pattern, value string) bool {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return false
+	}
+	return re.MatchString(value)
 }
 
 // 文件是否存在

--- a/util/utils_test.go
+++ b/util/utils_test.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/pingc0y/URLFinder/cmd"
+)
+
+func TestGetProtocolReturnsEmptyWhenBothSchemesFail(t *testing.T) {
+	got := GetProtocol("127.0.0.1:1")
+	if got != "" {
+		t.Fatalf("GetProtocol() = %q, want empty string for unreachable host", got)
+	}
+}
+
+func TestRegexpMatchReturnsFalseForInvalidRegexp(t *testing.T) {
+	if RegexpMatch("[", "https://example.com") {
+		t.Fatal("RegexpMatch() returned true for invalid regexp")
+	}
+}
+
+func TestDomainNameFilterReturnsEmptyForInvalidRegexp(t *testing.T) {
+	oldD := cmd.D
+	t.Cleanup(func() {
+		cmd.D = oldD
+	})
+
+	cmd.D = "["
+
+	got := domainNameFilter("https://example.com")
+	if got != "" {
+		t.Fatalf("domainNameFilter() = %q, want empty string for invalid regexp", got)
+	}
+}
+
+func TestReadAllLimitedRejectsOversizedBody(t *testing.T) {
+	_, err := readAllLimited(strings.NewReader("abcd"), 3)
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("readAllLimited() error = %v, want ErrResponseTooLarge", err)
+	}
+}


### PR DESCRIPTION
## 变更内容

- 修复 `go.sum` 损坏导致 Go 工具链无法运行的问题。
- 修复不可访问域名自动识别协议时的空指针 panic。
- 修复小线程数（如 `-t 1`）下验证阶段通道容量为 0 导致卡死的问题。
- 安全处理非法 `-d` 正则，避免 `regexp.MustCompile` 直接 panic。
- 转义 HTML 报告中的 URL、标题、来源和敏感信息字段，降低报告注入风险。
- 限制目标响应体读取大小，避免无限制 `ReadAll` 占用内存。
- 过滤 `data:`、`mailto:`、`javascript:`、`tel:` 和纯锚点等不可抓取引用，减少误报。
- 增加回归测试覆盖上述稳定性和安全修复。

## 验证

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `go test -race ./...`
- `go run . -u https://example.com -s all -m 1 -time 5 -t 10`

## Release

已推送 tag `2026.6.16`，GoReleaser workflow 已成功发布 Release。
